### PR TITLE
Add support for using quarter as R.E.

### DIFF
--- a/lib/calc_bpue.R
+++ b/lib/calc_bpue.R
@@ -92,8 +92,8 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat) {
     # vector below, added to the model as random effects.
     if (nrow(dat) >= 5) {
 
-        re <- c("country", "areacode", "year", "metierl5", "vessellength_group",
-                "samplingprotocol", "monitoringmethod")
+        re <- c("country", "areacode", "year", "quarter", "metierl5", 
+                "vessellength_group", "samplingprotocol", "monitoringmethod")
 
         # but only consider r.e. terms where the number of unique values 
         # (i.e. levels) is greater than min_re_obs. Note that this effectively

--- a/lib/generate_the_list.R
+++ b/lib/generate_the_list.R
@@ -5,15 +5,17 @@
 
 
 
-
-
+# aggregation step
+# AM 2026-01-05: added quarter, defined as jan-mar=>1, apr-jun=>2, jul-sep=>3, oct-dec=>4
+obs2[, quarter := as.integer(factor(month, levels = 1:12, labels = rep(1:4, each = 3)))]
 obs3 = obs2[!is.na(ecoregion) & !is.na(country), .(daysatsea = sum(daysatseaob, na.rm = TRUE)),
-                   by = .(ecoregion, areacode, country, year,
+                   by = .(ecoregion, areacode, country, year, quarter,
                           metierl4, metierl5, vessellength_group,
                           samplingprotocol, monitoringmethod)]
 
+bycatch2[, quarter := as.integer(factor(month, levels = 1:12, labels = rep(1:4, each = 3)))]
 bycatch3 = bycatch2[, .(n_ind = sum(n_individ, na.rm = TRUE)),
-                       by = .(ecoregion, areacode, country, year,
+                       by = .(ecoregion, areacode, country, year, quarter,
                               metierl4, metierl5, vessellength_group,
                               samplingprotocol, monitoringmethod, species)]
 ###


### PR DESCRIPTION
We now aggregate obs/bycatch data by quarter, and consider quarter as a candidate r.e. in calc_bpue().