### PR TITLE
New add_color_flag.r function with integration in main markdown + Bug corrections in produce_table_and_overall_figures.r

### DIFF
--- a/BEAM walkthrough.Rmd
+++ b/BEAM walkthrough.Rmd
@@ -685,8 +685,19 @@ bpues_estimates$reliability2[bpues_estimates$delta<2&bpues_estimates$upper_facto
 
 temp<-merge(table.print,bpues_estimates,by.x=c("Ecoregion","metier L4","Species"),by.y=c("Ecoregion","metier.L4","Species"),all.x=TRUE)
 
-table.print$reliability<-"uncertain"
-table.print$reliability[which(temp$reliability2==TRUE)]<-"more reliable"
+#Adding the color flag at this point. Need to go through a TRUE/FALSE version of the reliability column, as below in the metier L5 / ICES area examples.
+
+table.print$reliability<-FALSE
+table.print$reliability[which(temp$reliability2==TRUE)]<-TRUE
+
+table.print <- add_color_flag(table.print, bpue2) #Uses monitoring coverage from bpue2 and reliability info present in table.print
+
+#Convert TRUE/FALSE to qualifiers for printing
+table.print$reliability <- ifelse(
+  table.print$reliability,
+  "more reliable",
+  "uncertain"
+)
 
 fwrite(table.print,file="results/bpue_table_print.csv",na="NA")
 
@@ -725,6 +736,21 @@ icesareacases$delta<-log10(icesareacases$tot_upr+1)-log10(icesareacases$tot_lwr+
 icesareacases$reliability2<-FALSE
 icesareacases$reliability2[icesareacases$reliability==TRUE&icesareacases$delta<2]<-TRUE
 
+#Adding the color flag at this point.
+
+#The column output from reliability2 needs to be called reliability as in the example above at the ecoregion x metierl4 scale.
+
+icesareacases$reliability <- icesareacases$reliability2 
+
+icesareacases <- add_color_flag(icesareacases, bpue2_area) #Uses monitoring coverage from bpue2_area and reliability info present in icesareacases
+
+#Convert TRUE/FALSE to qualifiers
+icesareacases$reliability <- ifelse(
+  icesareacases$reliability,
+  "more reliable",
+  "uncertain"
+)
+
 fwrite(icesareacases,file="results/icesareacases.csv")
 
 #########
@@ -738,6 +764,22 @@ L5cases$delta<-log10(L5cases$tot_upr+1)-log10(L5cases$tot_lwr+1)
 
 L5cases$reliability2<-FALSE
 L5cases$reliability2[L5cases$reliability==TRUE&L5cases$delta<2]<-TRUE
+
+#Adding the color flag at this point.
+
+#The column output from reliability2 needs to be called reliability as in the example above at the ecoregion x metierl4 scale.
+
+L5cases$reliability <- L5cases$reliability2 
+
+L5cases <- add_color_flag(L5cases, bpue2_L5) #Uses monitoring coverage from bpue2_L5 and reliability info present in L5cases
+
+#Convert TRUE/FALSE to qualifiers
+L5cases$reliability <- ifelse(
+  L5cases$reliability,
+  "more reliable",
+  "uncertain"
+)
+
 
 fwrite(L5cases,file="results/L5cases.csv")
 
@@ -794,4 +836,5 @@ knitr::include_graphics("results/totalbycatch_elasmobranchs_reliability_check_or
 ```{r, echo=FALSE, out.width="90%"}
 knitr::include_graphics("results/totalbycatch_fish_reliability_check_ordered.png")
 ```
+
 

--- a/lib/add_color_flag.R
+++ b/lib/add_color_flag.R
@@ -1,16 +1,16 @@
-#07/01/2026
+#07/01/2026 - MP
 
-#This function adds a combined flag taking into account monitoring coverage and reliability estimations. The flag is the HEX code for a color on a bivariate palette, that can be used for plotting.
-#We also add an additional descriptive column "flag_description" 
-#The function is designed to work on the output from the function "reliability_estimation_p.R", and makes use of the "bpue_estimates" object 
+#This function adds a combined flag taking into account monitoring coverage and reliability estimations. The flag is a color on a bivariate palette, but we also add an additional descriptive column. 
+#The function is designed to work on the output from the function "reliability_estimation_p.R" or "reliability_estimation_p_ready.R", and makes use of the "bpue_estimates" object 
 #It take "cols" as an argument, to recover monitoring coverage from "bpue2" (output from "annotate_bpue.R") at the correct aggregation level. (annotate_bpue.R also takes the cols argument and can be run a different aggregation levels). 
-#Currently, the reliability test function is only implemented at an ecoregion / métier level 4 scale (not métier level 5 or ICES area), so by default, cols = c("ecoregion", "metierl4")
+#By default, cols = c("ecoregion", "metierl4"), but this can be amended to include metier level 5 or area code.
 
 add_color_flag <- function(bpues_estimates, bpue2, cols = c("ecoregion", "metierl4")) {
-  #Recovering the monitoring coverage info annotated in bpue2, at the same level of aggregation ("cols") - most of the time, cols=c("ecoregion", "metierl4"))
   
-  #This first part deals with difference in column names since we're working of an object in which column names were altered for printing. Not very clean, we might want to improve this in the future ?
-  #There might be a faster way of doing this.
+ 
+  
+  #This first part deals with difference in column names in cases where we're working of an object in which column names were altered for printing (e.g. table.print). 
+#Added this because in the markdown, reliability_estimation_p.R is run on bpue_table_print which has capital letters and spaces in column names, but reliability_estimation_p_ready.R to get similar results at area, metier L5 scales is run directly on the bpue1_area objects, output from calc_bpue, where column names are all lowercase. Tried to make it flexible depending on which object is used.
   
   original_colnames <- colnames(bpues_estimates)
   
@@ -21,7 +21,7 @@ add_color_flag <- function(bpues_estimates, bpue2, cols = c("ecoregion", "metier
     `ICES area`  = "areacode" #Not sure how ICES area column is called in table_print for estimates at the area scale. Is it implemented yet ?
   )
   
-  # Compute which of the internal names are requested and present
+  # Determine which of the capitalised bpue_estimates colnames names are requested and present
   requested <- intersect(names(bpues_estimates), names(names_changes))
   to_rename <- requested[names_changes[requested] %in% cols]
   
@@ -31,9 +31,13 @@ add_color_flag <- function(bpues_estimates, bpue2, cols = c("ecoregion", "metier
     setnames(bpues_estimates, old = to_rename, new = unname(names_changes[to_rename]))
   }
   
-  setnames(bpues_estimates, "Species", "species")
+  if ("Species" %in% names(bpues_estimates)) {
+    setnames(bpues_estimates, "Species", "species")
+  }
+
+   #Recovering the monitoring coverage info annotated in bpue2, at the same level of aggregation ("cols") - most of the time, cols=c("ecoregion", "metierl4"))
   
-  bpues_estimates[bpue2,on = c("species", cols),`Monitoring coverage` := i.monitoring_coverage] #This column actually already exists at the moment, just set up the function like this if we ever want to go to different level of aggregations.
+  bpues_estimates[bpue2,on = c("species", cols),`Monitoring coverage` := i.monitoring_coverage] #This column actually already exists if the input object is derived from table_print, but set up the function like this so it can be run wether bpues_estimates is the output of reliability_estimation_p.R (run on table_print format, already contains Monitoring coverage), or reliability_estimation_p_ready.R (run on calc_bpue bpue1 output, does not contain monitoring coverage info)
   
   colnames(bpues_estimates) <- c(original_colnames) # Going back to original names after join
   
@@ -59,5 +63,3 @@ add_color_flag <- function(bpues_estimates, bpue2, cols = c("ecoregion", "metier
   
   bpues_estimates
 }
-
-

--- a/lib/add_color_flag.R
+++ b/lib/add_color_flag.R
@@ -1,0 +1,63 @@
+#07/01/2026
+
+#This function adds a combined flag taking into account monitoring coverage and reliability estimations. The flag is the HEX code for a color on a bivariate palette, that can be used for plotting.
+#We also add an additional descriptive column "flag_description" 
+#The function is designed to work on the output from the function "reliability_estimation_p.R", and makes use of the "bpue_estimates" object 
+#It take "cols" as an argument, to recover monitoring coverage from "bpue2" (output from "annotate_bpue.R") at the correct aggregation level. (annotate_bpue.R also takes the cols argument and can be run a different aggregation levels). 
+#Currently, the reliability test function is only implemented at an ecoregion / métier level 4 scale (not métier level 5 or ICES area), so by default, cols = c("ecoregion", "metierl4")
+
+add_color_flag <- function(bpues_estimates, bpue2, cols = c("ecoregion", "metierl4")) {
+  #Recovering the monitoring coverage info annotated in bpue2, at the same level of aggregation ("cols") - most of the time, cols=c("ecoregion", "metierl4"))
+  
+  #This first part deals with difference in column names since we're working of an object in which column names were altered for printing. Not very clean, we might want to improve this in the future ?
+  #There might be a faster way of doing this.
+  
+  original_colnames <- colnames(bpues_estimates)
+  
+  names_changes <- c(
+    Ecoregion = "ecoregion",
+    `metier L4`  = "metierl4",
+    `metier L5`  = "metierl5",
+    `ICES area`  = "areacode" #Not sure how ICES area column is called in table_print for estimates at the area scale. Is it implemented yet ?
+  )
+  
+  # Compute which of the internal names are requested and present
+  requested <- intersect(names(bpues_estimates), names(names_changes))
+  to_rename <- requested[names_changes[requested] %in% cols]
+  
+  # Rename in place (only if there’s something to rename)
+  
+  if (length(to_rename)) {
+    setnames(bpues_estimates, old = to_rename, new = unname(names_changes[to_rename]))
+  }
+  
+  setnames(bpues_estimates, "Species", "species")
+  
+  bpues_estimates[bpue2,on = c("species", cols),`Monitoring coverage` := i.monitoring_coverage] #This column actually already exists at the moment, just set up the function like this if we ever want to go to different level of aggregations.
+  
+  colnames(bpues_estimates) <- c(original_colnames) # Going back to original names after join
+  
+  bpues_estimates[`Monitoring coverage` < 0.001 & reliability == FALSE, color := "#D25600"]
+  bpues_estimates[`Monitoring coverage` < 0.001 & reliability == TRUE, color := "#D3D3D3"]
+  
+  bpues_estimates[`Monitoring coverage` >= 0.001 & `Monitoring coverage` <= 0.005 & reliability == FALSE, color := "#923500"]
+  bpues_estimates[`Monitoring coverage` >= 0.001 & `Monitoring coverage` <= 0.005 & reliability == TRUE, color := "#9283AC"]
+  
+  bpues_estimates[`Monitoring coverage` > 0.005 & reliability == FALSE, color := "#541600"]
+  bpues_estimates[`Monitoring coverage` > 0.005 & reliability == TRUE, color := "#553687"]
+  
+  #Add a qualitative description of the color coding:
+  
+  bpues_estimates[`Monitoring coverage` < 0.001 & reliability == FALSE, flag_description := "Uncertain estimate and poor monitoring coverage - values should not be used for advice"]
+  bpues_estimates[`Monitoring coverage` < 0.001 & reliability == TRUE, flag_description := "Estimate more reliable but poor monitoring coverage - values should not be used for advice"]
+  
+  bpues_estimates[`Monitoring coverage` >= 0.001 & `Monitoring coverage` <= 0.005 & reliability == FALSE, flag_description := "Uncertain estimate and low monitoring coverage"]
+  bpues_estimates[`Monitoring coverage` >= 0.001 & `Monitoring coverage` <= 0.005 & reliability == TRUE, flag_description := "More reliable estimate but low monitoring coverage"]
+  
+  bpues_estimates[`Monitoring coverage` > 0.005 & reliability == FALSE, flag_description := "Uncertain estimate and monitoring coverage above satisfactory threshold"]
+  bpues_estimates[`Monitoring coverage` > 0.005 & reliability == TRUE, flag_description := "More reliable estimate and monitoring coverage above satisfactory threshold"]
+  
+  bpues_estimates
+}
+
+

--- a/lib/produce_table_and_overall_figures.r
+++ b/lib/produce_table_and_overall_figures.r
@@ -92,6 +92,9 @@ complete_tb2print<-merge(complete_tb2print,bpue1,c("ecoregion","metierl4","speci
 complete_tb2print<-merge(complete_tb2print,summaryyear,c("ecoregion","metierl4","species"),all.x=TRUE)
 complete_tb2print<-merge(complete_tb2print,summaryall,c("ecoregion","metierl4","species"),all.x=TRUE)
 
+complete_tb2print[common_names,on = c("species"), taxa := i.taxon]
+complete_tb2print[common_names,on = c("species"), common := i.common]
+
 CTB_sum = complete_tb2print[
   ,
   .(n_ind = sum(n_ind),
@@ -264,4 +267,5 @@ dev.off()
 png("results/totalbycatch_fish.png",width=20,height=35,units="cm",res=200)
 fish
 dev.off()
+
 

--- a/lib/produce_table_and_overall_figures.r
+++ b/lib/produce_table_and_overall_figures.r
@@ -7,24 +7,29 @@ table2print<-merge(table2print,bpue1,by=c("ecoregion","metierl4","species"),all=
 table2print<-merge(table2print,summaryyear,by=c("ecoregion","metierl4","species"),all.x=TRUE)
 table2print<-merge(table2print,summaryall,by=c("ecoregion","metierl4","species"),all.x=TRUE)
 
+###MP 07/01/26: Added a few steps to recover taxa information that is not in total_bycatch but required in lines below.
+common_names <- fread("data/commonnames2024.csv")
+common_names$common <- tolower(common_names$common)
+common_names$taxon <- tolower(common_names$taxon)
+table2print[common_names,on = c("species"), taxa := i.taxon]
+table2print[common_names,on = c("species"), common := i.common]
+###
 
 #dat$n_ind / dat$daysatsea
 
 table.print<-table2print[,c("ecoregion","metierl4","taxa","species","common","n_ind","daysatsea","fishing_effort","n_ind_all","daysatsea_all","model.x","bpue","lwr","upr","tbfinal.mean","tbfinal.lwr","tbfinal.upr")]
 
-
-
-
 table.print$interannual<-"none apparent"
 table.print$interannual[grep("year",table.print$model)]<-"there is between-year variability in BPUE"
 
+#07/01/2026: Removed capital letters in variable names so grep() works properly
 table.print$key.representability<-"a constant BPUE appears to be representative"
-table.print$key.representability[grep("metierL5",table.print$model)]<-"there is between-metier level 5 variability in BPUE"
-table.print$key.representability[grep("vesselLength_group",table.print$model)]<-"there is between-vessel length category variability in BPUE"
-table.print$key.representability[grep("areaCode",table.print$model)]<-"there is spatial variability in BPUE"
+table.print$key.representability[grep("metierl5",table.print$model)]<-"there is between-metier level 5 variability in BPUE"
+table.print$key.representability[grep("vessellength_group",table.print$model)]<-"there is between-vessel length category variability in BPUE"
+table.print$key.representability[grep("areacode",table.print$model)]<-"there is spatial variability in BPUE"
 table.print$key.representability[grep("country",table.print$model)]<-"there is spatial variability in BPUE"
-table.print$key.representability[grep("monitoringMethod",table.print$model)]<-"there is variability in BPUE depending on monitoring protocols"
-table.print$key.representability[grep("samplingProtocol",table.print$model)]<-"there is variability in BPUE depending on monitoring protocols"
+table.print$key.representability[grep("monitoringmethod",table.print$model)]<-"there is variability in BPUE depending on monitoring protocols"
+table.print$key.representability[grep("samplingprotocol",table.print$model)]<-"there is variability in BPUE depending on monitoring protocols"
 
 table.print$n_ind<-round(table.print$n_ind,0)
 table.print$daysatsea<-round(table.print$daysatsea,0)
@@ -259,3 +264,4 @@ dev.off()
 png("results/totalbycatch_fish.png",width=20,height=35,units="cm",res=200)
 fish
 dev.off()
+

--- a/lib/produce_table_and_overall_figures.r
+++ b/lib/produce_table_and_overall_figures.r
@@ -28,8 +28,8 @@ table.print$key.representability[grep("metierl5",table.print$model)]<-"there is 
 table.print$key.representability[grep("vessellength_group",table.print$model)]<-"there is between-vessel length category variability in BPUE"
 table.print$key.representability[grep("areacode",table.print$model)]<-"there is spatial variability in BPUE"
 table.print$key.representability[grep("country",table.print$model)]<-"there is spatial variability in BPUE"
-table.print$key.representability[grep("monitoringmethod",table.print$model)]<-"there is variability in BPUE depending on monitoring protocols"
-table.print$key.representability[grep("samplingprotocol",table.print$model)]<-"there is variability in BPUE depending on monitoring protocols"
+table.print$key.representability[grep("monitoringmethod",table.print$model)]<-"there is variability in BPUE depending on monitoring methods"
+table.print$key.representability[grep("samplingprotocol",table.print$model)]<-"there is variability in BPUE depending on sampling protocols"
 
 table.print$n_ind<-round(table.print$n_ind,0)
 table.print$daysatsea<-round(table.print$daysatsea,0)
@@ -267,5 +267,6 @@ dev.off()
 png("results/totalbycatch_fish.png",width=20,height=35,units="cm",res=200)
 fish
 dev.off()
+
 
 


### PR DESCRIPTION
Created a new function to add a combined monitoring coverage and reliability flag column to tables (bivariate color palette). Should run on outputs from reliability_estimation_p.R (ecoregion, metier level 4) or reliability_estimation_p_ready.R (custom aggregation levels). "color" column is a HEX code that can be used for plots, "flag_description" is a explanation of the flag (e.g. "More reliable estimate but poor monitoring coverage")

Integrated function in main walkthrough markdown, both for ecoregion x métierl4 scale and areas or métier l5 scales. 
Not yet applied to the plots.

Fixed a few bugs in produce_table_and_overall_figures.r:

- Added steps to pull taxon and common names information from commonnames2024.csv. Those columns were required but not present in total_bycatch object used in the function.
- Corrected variable names to lower case in the grep() steps so the code returns info on bpue variability as intended.

Note: there is still a bug at line 151 that prevents the function from running: priority3 is not a defined object.