### PR TITLE
Using outputs from heterogeneity test as conditions for best model selection in calc_bpue and total bycatch estimation in calc_total

### DIFF
--- a/lib/calc_bpue.R
+++ b/lib/calc_bpue.R
@@ -135,8 +135,13 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
   
         })
         
-        # pick the best one
+        # pick the best one, unless there was no heterogeneity detected, in that case, keep base model
         candidates.converged <- candidates[which(sapply(candidates, class) != "character")]
+		if (isFALSE(ret$base_model_heterogeneity)) {
+
+  best_model <- base_model
+
+}	 else {				   
         scores <- sapply(candidates.converged, AIC)
         if (length(scores) > 1 & sum(!is.na(scores)) > 0) {
             best <- candidates.converged[[which.min(scores)]]
@@ -156,5 +161,6 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     return(ret)
     
 }
+
 
 

--- a/lib/calc_bpue.R
+++ b/lib/calc_bpue.R
@@ -139,14 +139,15 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
         candidates.converged <- candidates[which(sapply(candidates, class) != "character")]
 		if (isFALSE(ret$base_model_heterogeneity)) {
 
-  best_model <- base_model
+  		best_model <- base_model
 
-}	 else {				   
+		}	 else {				   
         scores <- sapply(candidates.converged, AIC)
         if (length(scores) > 1 & sum(!is.na(scores)) > 0) {
             best <- candidates.converged[[which.min(scores)]]
         }
     }
+	}
     
     if (class(best) != "character") {
         bpue.r <- as.data.frame(emmeans(best, ~1, type="response", offset = log(1))) # BPUE for one DaS we can push to total effort prediction instead next
@@ -161,6 +162,7 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     return(ret)
     
 }
+
 
 
 

--- a/lib/calc_total.R
+++ b/lib/calc_total.R
@@ -64,6 +64,13 @@ calc_total <- function(bpue, cols = c("ecoregion", "metierl4", "species"), obs, 
         return(ret)
     }
     
+    # don't try to generate total estimates for models with unexplained heterogeneity (base_model_heterogeneity = TRUE but best model is n_ind~1)
+    if (re.n == 0 && isTRUE(bpue$base_model_heterogeneity)) {
+      ret$message <- "unable to explain heterogeneity with candidate random effects"
+      return(ret)
+    }
+    
+    
     # sum up total fishing effort per combination of all levels of the random effects
     tot <- allx[bpue, on = cols[cols != "species"], .(das_fishing = sum(daysatseaf), final_year = max(year)), by = re]
     #tot[, logDAS := log(das)] # OUTI: Days at sea is on a log scale
@@ -148,3 +155,4 @@ calc_total <- function(bpue, cols = c("ecoregion", "metierl4", "species"), obs, 
     
     return(ret)
 }
+


### PR DESCRIPTION
New rules:
- If base_model_heterogeneity = FALSE, best_model is base_model, regardless of AIC
- If best_model is 1~n_ind (no random effects), but heterogeneity was detected, do not estimate total bycatch, but flag unexplained variability in BPUEs