### PR TITLE
Updates to calc_bpue and calc_total

### DIFF
--- a/lib/calc_bpue.R
+++ b/lib/calc_bpue.R
@@ -135,8 +135,13 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
   
         })
         
-        # pick the best one
+        # pick the best one, unless there was no heterogeneity detected, in that case, keep base model
         candidates.converged <- candidates[which(sapply(candidates, class) != "character")]
+		if (isFALSE(ret$base_model_heterogeneity)) {
+
+  best_model <- base_model
+
+}	 else {				   
         scores <- sapply(candidates.converged, AIC)
         if (length(scores) > 1 & sum(!is.na(scores)) > 0) {
             best <- candidates.converged[[which.min(scores)]]
@@ -156,5 +161,6 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     return(ret)
     
 }
+
 
 

--- a/lib/calc_bpue.R
+++ b/lib/calc_bpue.R
@@ -139,14 +139,15 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
         candidates.converged <- candidates[which(sapply(candidates, class) != "character")]
 		if (isFALSE(ret$base_model_heterogeneity)) {
 
-  best_model <- base_model
+  		best_model <- base_model
 
-}	 else {				   
+		}	 else {				   
         scores <- sapply(candidates.converged, AIC)
         if (length(scores) > 1 & sum(!is.na(scores)) > 0) {
             best <- candidates.converged[[which.min(scores)]]
         }
     }
+	}
     
     if (class(best) != "character") {
         bpue.r <- as.data.frame(emmeans(best, ~1, type="response", offset = log(1))) # BPUE for one DaS we can push to total effort prediction instead next
@@ -161,6 +162,7 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     return(ret)
     
 }
+
 
 
 

--- a/lib/calc_bpue.R
+++ b/lib/calc_bpue.R
@@ -4,13 +4,21 @@
 #' @description
 #' `calc_bpue` takes monitored fishing effort data obtained in the ICES WGBYC
 #' annual data call, and uses those data to generate a number of models of varying
-#' complexity. It then compares those models using AIC, and returns the best model.
+#' complexity. It then compares those models using the Akaike Information Criterion (AIC), combined with a stability 
+#' filter and a parsimony rule
 #' @details
 #' If there are multiple rows in `needle`, each row is processed separately, and
 #' rbind'ed into one data.table with nrow equal to the number of rows in `needle`.
 #' If a parallel backend is available, the code will execute in parallel, allowing
 #' faster computations.
-#' 
+
+#' The model selection uses **AIC** with a **Parsimony Rule**:
+#' 1. **Model Selection**: Valid combinations of random effects are fitted. Models with 
+#'    "Singular Fit" (near-zero variance or perfect correlation) are 
+#'    discarded to ensure numerical stability and prevent over-parameterization.
+#' 2. **Tie-breaker**: Among stable candidates, if the difference in AIC is < 2, 
+#'    the simpler model (fewer random effects) is chosen, but flagged under "alternative_models_flag".
+
 #' @param needle data.table with values for `cols`, used to subset observations from `dat`. Any additional columns in `needle` are disregarded.
 #' @param cols columns, whose unique combinations, are used to split the data given in `dat`
 #' @param min_re_obs Integer specifying the minimum number of levels needed to include a term as a random effect
@@ -61,14 +69,15 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     dat <- dat[daysatsea > 0]
     dat[, (cols) := lapply(.SD, as.factor), .SDcols = cols]
     dat[, logDAS := log(daysatsea)]
+	dat[, n_ind := as.integer(n_ind)] 
     
     # add observation weights to data(if monitoring within the last five years 
     # use full weight, if older data weight observations half as strongly in the likelihood)
     dat[, weights := ifelse(year >= (max(years)-4),1,0.5)] 
     
     ret <- needle[, ..cols]
-    ret[, c("model", "bpue", "lwr", "upr", "replicates", "base_model_heterogeneity") :=
-            list("none", NA_real_, NA_real_, NA_real_, nrow(dat), NA)]
+    ret[, c("model", "bpue", "lwr", "upr", "replicates", "base_model_heterogeneity", "alternative_models_flag") :=
+            list("none", NA_real_, NA_real_, NA_real_, nrow(dat), NA, FALSE)]
 
     if ((nrow(dat) == 0) | (sum(dat$n_ind, na.rm = TRUE) == 0) | any(dat$n_ind < 0)) {
         return(ret)
@@ -93,7 +102,7 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     heterogeneity <- tryCatch((rma.glmm(xi = n_ind, ti = daysatsea, measure = "IRLN", data = dat)$QEp.Wld<0.05), error = function(e) e$message)
     
     
-    if (class(heterogeneity) != "character") {
+    if (!inherits(heterogeneity, "character")) {
         ret$base_model_heterogeneity <- heterogeneity
     }
     
@@ -104,57 +113,154 @@ calc_bpue <- function(needle, cols = colnames(needle), min_re_obs = 2, dat, year
     # vector below, added to the model as random effects.
     if (nrow(dat) >= 5) {
 
-        re <- c("country", "areacode", "year", "quarter", "metierl5", 
+        re_terms <- c("country", "areacode", "year", "quarter", "metierl5", 
                 "vessellength_group", "samplingprotocol", "monitoringmethod")
 
         # but only consider r.e. terms where the number of unique values 
         # (i.e. levels) is greater than min_re_obs. Note that this effectively
         # prevents any variables specified in the cols parameter from being included
         # as random effects in any models, since they will always have length=1.
-        re <- re[sapply(re, function(x) length(unique(dat[[x]]))) >= min_re_obs]
-        re.i <- do.call(CJ, replicate(length(re), c(TRUE, FALSE), simplify = FALSE)) # all possible combinations of random effect levels
-        
-        # fit all candidate models 
-        candidates <- apply(re.i, 1, function(i) {
-            
-            if (all(i == FALSE)) {
-                return(base_model)
+        re_terms <- re_terms[sapply(re_terms, function(x) length(unique(dat[[x]]))) >= min_re_obs]
+        re.i <- do.call(CJ, replicate(length(re_terms), c(TRUE, FALSE), simplify = FALSE)) # all possible combinations of random effect levels
+
+		re_candidates <- apply(re.i, 1, function(i) {
+        if (all(i == FALSE)) return("1")
+        terms <- sprintf("(1|%s)", re_terms[unlist(i)])
+        return(paste("1 +", paste(terms, collapse = " + ")))
+        })							
+
+	## MP: 09/02/2026
+	## Integration of two versions of calc_bpue:
+	# New model selection function written by KMB, including singularity checks and parsimony rule, 
+	# New option of using weights in models, developped by TS
+
+	  candidates <- lapply(re_candidates, function(f_str) {
+      curr_formula <- as.formula(sprintf("n_ind ~ %s", f_str))
+      fit <- suppressMessages(tryCatch({
+		 if(isTRUE(include.weights)){
+             m <- glmmTMB(formula = curr_formula, offset = logDAS, family = nbinom2, data = dat, weights = weights)
+            }else{
+             m <- glmmTMB(formula = curr_formula, offset = logDAS, family = nbinom2, data = dat)
             }
+       
+        # Check for Singularity in glmmTMB
+        vc <- VarCorr(m)$cond
+        is_singular <- FALSE
+        for (comp in vc) {
+          if (any(diag(comp) < 1e-6)) is_singular <- TRUE # Variance near zero
+          if (nrow(comp) > 1) {
+            cor_mat <- attr(comp, "correlation")
+            if (any(abs(cor_mat[lower.tri(cor_mat)]) > 0.99)) is_singular <- TRUE # Near perfect correlation
+          }
+        }
+        
+        if (!is_singular) return(m) else return("Singular") 
+      }, error = function(e) e$message))
+      return(fit)
+    })
+    
+    # Identify Valid glmmTMB objects
+    valid_indices <- which(sapply(candidates, function(x) inherits(x, "glmmTMB")))
+    
+    if (length(valid_indices) > 0) {
+      # Use AIC instead of BIC for more balanced complexity selection
+      valid_aics <- sapply(candidates[valid_indices], AIC)
+      valid_complexity <- lengths(regmatches(re_candidates[valid_indices], gregexpr("\\+", re_candidates[valid_indices])))
+      
+      sel_table <- data.table(
+        Index = valid_indices,
+        AIC = valid_aics,
+        Complexity = valid_complexity
+      )
+      
+      sel_table <- sel_table[is.finite(AIC)]
+      
+      if (nrow(sel_table) > 0) {
+        min_aic <- min(sel_table$AIC)
+        # Zone of indifference (delta AIC < 2)
+        top_tier <- sel_table[AIC <= (min_aic + 2)]
+        
+        # Parsimony Rule: Choose simplest model in the top tier
+        setorder(top_tier, Complexity, AIC)
+        
+        best_idx <- top_tier$Index[1]
+        best <- candidates[[best_idx]]
+        
+        if (nrow(top_tier) > 1) {
+          ret$alternative_models_flag <- TRUE
+        }
+      }
+    }
+  }
+  
+  # Final check for model validity before emmeans
+  if (inherits(best, "glmmTMB")) {
+    bpue.r <- tryCatch(as.data.frame(emmeans(best, ~1, type="response", offset = log(1))),
+                       error = function(e) NULL)
+    if (!is.null(bpue.r)) {
+      ret[, c("bpue", "lwr", "upr") := as.list(bpue.r[, c("response", "asymp.LCL", "asymp.UCL")])]
+    }
+  }
+  
+  # Format the model formula as a string
+  if (inherits(best, "glmmTMB")) {
+    ret[, model := paste(format(formula(best)), collapse = "")]
+  } else {
+    ret[, model := as.character(best)]
+  }
+
+	# In cases where no heterogeneity was detected, over-write best model by base model
+
+  if (isFALSE(base_model_heterogeneity)) {
+    ret[, model := paste(format(formula(base_model)), collapse = "")]
+  } else {}
+									
+
+## MP: below is Legacy code - included weight option but old model selection approach - new version should integrate both but keeping the code below in case bugs occur.
+#########							
+        # fit all candidate models 
+        #candidates <- apply(re.i, 1, function(i) {
             
-            re <- sprintf("(1|%s)", re[unlist(i)])
-            form <- sprintf("n_ind ~ 1 + %s", paste(re, collapse = " + "))
-            form <- as.formula(form)
+           # if (all(i == FALSE)) {
+                #return(base_model)
+            #}
+            
+            #re <- sprintf("(1|%s)", re[unlist(i)])
+            #form <- sprintf("n_ind ~ 1 + %s", paste(re, collapse = " + "))
+            #form <- as.formula(form)
             # wrapped this in suppressMessages just to avoid cluttering of the console when running glmmTMB, errors and warnings are still caught by tryCatch.
             
             # fit model either including or excluding model weights
-            if(isTRUE(include.weights)){
-              suppressMessages(tryCatch(glmmTMB(formula = form, offset = logDAS, family = nbinom2, data = dat, weights = weights), error = function(e) e$message, warning = function(w) w$message))  
-            }else{
-              suppressMessages(tryCatch(glmmTMB(formula = form, offset = logDAS, family = nbinom2, data = dat), error = function(e) e$message, warning = function(w) w$message))  
-            }
+            #if(isTRUE(include.weights)){
+            #  suppressMessages(tryCatch(glmmTMB(formula = form, offset = logDAS, family = nbinom2, data = dat, weights = weights), error = function(e) e$message, warning = function(w) w$message))  
+            #}else{
+            #  suppressMessages(tryCatch(glmmTMB(formula = form, offset = logDAS, family = nbinom2, data = dat), error = function(e) e$message, warning = function(w) w$message))  
+            #}
   
-        })
+       # })
         
         # pick the best one
-        candidates.converged <- candidates[which(sapply(candidates, class) != "character")]
-        scores <- sapply(candidates.converged, AIC)
-        if (length(scores) > 1 & sum(!is.na(scores)) > 0) {
-            best <- candidates.converged[[which.min(scores)]]
-        }
-    }
+        #candidates.converged <- candidates[which(sapply(candidates, class) != "character")]
+        #scores <- sapply(candidates.converged, AIC)
+        #if (length(scores) > 1 & sum(!is.na(scores)) > 0) {
+        #    best <- candidates.converged[[which.min(scores)]]
+        #}
+    #}
     
-    if (class(best) != "character") {
-        bpue.r <- as.data.frame(emmeans(best, ~1, type="response", offset = log(1))) # BPUE for one DaS we can push to total effort prediction instead next
-        ret[, c("bpue", "lwr", "upr") := as.list(bpue.r[, c("response", "asymp.LCL", "asymp.UCL")])]
-    }
+    #if (class(best) != "character") {
+        #bpue.r <- as.data.frame(emmeans(best, ~1, type="response", offset = log(1))) # BPUE for one DaS we can push to total effort prediction instead next
+        #ret[, c("bpue", "lwr", "upr") := as.list(bpue.r[, c("response", "asymp.LCL", "asymp.UCL")])]
+    #}
 
-    ret[, model := paste(format(formula(best)), collapse = "")]
-    
+    #ret[, model := paste(format(formula(best)), collapse = "")]
+    ###################
+							   
     t_end <- Sys.time()
     t_elapsed <- difftime(t_end,t_start,units="mins")
     cat(sprintf("calc_bpue on %d rows completed in %.01f mins\n", nrow(needle), t_elapsed))
     return(ret)
     
 }
+
 
 

--- a/lib/calc_total.R
+++ b/lib/calc_total.R
@@ -64,6 +64,13 @@ calc_total <- function(bpue, cols = c("ecoregion", "metierl4", "species"), obs, 
         return(ret)
     }
     
+    # don't try to generate total estimates for models with unexplained heterogeneity (base_model_heterogeneity = TRUE but best model is n_ind~1)
+    if (re.n == 0 && isTRUE(bpue$base_model_heterogeneity)) {
+      ret$message <- "unable to explain heterogeneity with candidate random effects"
+      return(ret)
+    }
+    
+    
     # sum up total fishing effort per combination of all levels of the random effects
     tot <- allx[bpue, on = cols[cols != "species"], .(das_fishing = sum(daysatseaf), final_year = max(year)), by = re]
     #tot[, logDAS := log(das)] # OUTI: Days at sea is on a log scale
@@ -148,3 +155,4 @@ calc_total <- function(bpue, cols = c("ecoregion", "metierl4", "species"), obs, 
     
     return(ret)
 }
+


### PR DESCRIPTION
Calc_bpue:
- Integration of the new model selection function by Kim Magnus Bærum with year weighing option from @torbjornsaterberg 
- New rule at the end: If no heterogeneity detected, overwrite best model by base model (n_ind~1), regardless of AIC scores.

Calc_total:
- New rule: If the best model does not include any random effect but heterogeneity was detected, do not attempt to estimate total bycatch, but instead return a message "unable to explain heterogeneity using candidate random effects"